### PR TITLE
feat: 루트 스토리 조회 API

### DIFF
--- a/src/main/java/com/nextpage/backend/dto/DatabaseLoader.java
+++ b/src/main/java/com/nextpage/backend/dto/DatabaseLoader.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class DatabaseLoader {
-//
+
 //    @Bean
 //    CommandLineRunner initDatabase(StoryRepository repository) {
 //        return args -> {

--- a/src/main/java/com/nextpage/backend/dto/response/RootResponseDTO.java
+++ b/src/main/java/com/nextpage/backend/dto/response/RootResponseDTO.java
@@ -1,0 +1,26 @@
+package com.nextpage.backend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RootResponseDTO {
+    private List<StoryInfo> stories;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class StoryInfo {
+        private Long id;
+        private String userNickname;
+        private String content;
+        private String imageUrl;
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/nextpage/backend/entity/Story.java
+++ b/src/main/java/com/nextpage/backend/entity/Story.java
@@ -23,12 +23,12 @@ public class Story {
     private String content;
     private String imageUrl;
 
-    // 부모 스토리와의 관계를 나타냅니다.
-    @Relationship(type = "PARENT_OF", direction = Relationship.Direction.INCOMING)
+    // 해당 노드를 자식으로 가지는 관계 : parent
+    @Relationship(type = "PARENT_OF", direction = Relationship.Direction.OUTGOING)
     private Story parentId;
 
-    // 자식 스토리와의 관계를 나타냅니다.
-    @Relationship(type = "PARENT_OF", direction = Relationship.Direction.OUTGOING)
+    // 해당 노드를 부모로 가지는 관계 : child
+    @Relationship(type = "PARENT_OF", direction = Relationship.Direction.INCOMING)
     private List<Story> childId;
 
     private LocalDateTime createdAt;

--- a/src/main/java/com/nextpage/backend/repository/StoryRepository.java
+++ b/src/main/java/com/nextpage/backend/repository/StoryRepository.java
@@ -2,8 +2,13 @@ package com.nextpage.backend.repository;
 
 import com.nextpage.backend.entity.Story;
 import org.springframework.data.neo4j.repository.Neo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+
+import java.util.List;
 
 public interface StoryRepository extends Neo4jRepository<Story,Long> {
 
-//    List<Story> findByUserNickname(String userNickname);
+    // 부모 관계가 없l
+    @Query("MATCH (s:Story) WHERE NOT (s)-[:PARENT_OF]->() RETURN s")
+    List<Story> findRootStories();
 }

--- a/src/main/java/com/nextpage/backend/service/StoryService.java
+++ b/src/main/java/com/nextpage/backend/service/StoryService.java
@@ -18,11 +18,11 @@ public class StoryService {
         this.storyRepository = storyRepository;
     }
 
-//    public List<Story> getStoriesByUserNickname(String userNickname) {
-//        return storyRepository.findByUserNickname(userNickname);
-//    }
+    public List<Story> getRootStories() { // parentId가 없는 루트 스토리들 조회
+        return storyRepository.findRootStories();
+    }
 
-    public StoryDetailsResponseDTO getStoryDetails(Long storyId) {
+    public StoryDetailsResponseDTO getStoryDetails(Long storyId) { // 스토리 상세 조회
         // storyId로 스토리 찾기
         Story story = storyRepository.findById(storyId).orElseThrow(() -> new NoSuchElementException("해당 ID의 스토리를 찾을 수 없습니다 [id: " + storyId + "]"));
 
@@ -32,9 +32,9 @@ public class StoryService {
         responseDTO.setContent(story.getContent());
         responseDTO.setImageUrl(story.getImageUrl());
         responseDTO.setUserNickname(story.getUserNickname());
-        responseDTO.setParentId(story.getParentId() != null ? story.getParentId().getId() : null);
 
-        // 자식 스토리 ID 및 내용을 설정
+        // 부모 자식 스토리의 ID와 content
+        responseDTO.setParentId(story.getParentId() != null ? story.getParentId().getId() : null);
         List<Long> childIds = story.getChildId().stream().map(Story::getId).collect(Collectors.toList());
         responseDTO.setChildId(childIds);
         List<String> childContents = story.getChildId().stream().map(Story::getContent).collect(Collectors.toList());


### PR DESCRIPTION
## Summary
*한 줄 설명*

루트 스토리 조회 API

## Description
- *어떤 코드가 추가/변경 됐는지*
- StoryController, StoryService, StoryRepository 코드 작성
- RootResponseDTO.java 추가
- Story 모델 Relationship 수정: root를 찾으려면 저 방향이 반대로 되어야되더라구욥
<img width="642" alt="스크린샷 2024-03-14 오후 11 45 32" src="https://github.com/Project-NextPage/nextpage_backend/assets/94193594/09d06df5-41a8-4e74-b5de-a060d532cfa3">

## Screenshots
*실행 결과 스크린샷*

<img width="1023" alt="스크린샷 2024-03-15 오후 3 35 07" src="https://github.com/Project-NextPage/nextpage_backend/assets/94193594/774cd821-ff64-4c41-9675-140e831e4f2c">

## Test Checklist
*테스트할 사람이 어떤 것을 확인하면 좋을지*
- [ ] 모델이 수정됐으므로 neo4j 데이터 다 지우고 DatabaseLoader 몇 번 돌려서 노드 다시 만들기
`MATCH (n)
DETACH DELETE n
` : 다 지우는 싸이퍼문
