### PR TITLE
refactor : 내 스토리 불러오기 토큰으로 닉네임 불러오도록 수정

### DIFF
--- a/src/main/java/com/nextpage/backend/controller/MypageController.java
+++ b/src/main/java/com/nextpage/backend/controller/MypageController.java
@@ -2,13 +2,11 @@ package com.nextpage.backend.controller;
 
 import com.nextpage.backend.config.jwt.TokenService;
 import com.nextpage.backend.dto.response.StoryListResponseDTO;
-import com.nextpage.backend.error.exception.user.UserNotFoundException;
 import com.nextpage.backend.repository.UserRepository;
 import com.nextpage.backend.result.ResultResponse;
 import com.nextpage.backend.service.MypageService;
 import com.nextpage.backend.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.nextpage.backend.result.ResultCode.MYPAGE_MYSTORY_LIST_SUCCESS;
 
@@ -27,23 +24,16 @@ import static com.nextpage.backend.result.ResultCode.MYPAGE_MYSTORY_LIST_SUCCESS
 public class MypageController {
 
     private final MypageService mypageService;
-    private final TokenService tokenService;
-    private final UserRepository userRepository;
-
 
     public MypageController(MypageService mypageService, UserService userService, TokenService tokenService, UserRepository userRepository) {
         this.mypageService = mypageService;
-        this.tokenService = tokenService;
-        this.userRepository = userRepository;
+
     }
 
-    @Operation(summary = "내가 쓴 스토리 조회", description = "특정 닉네임의 스토리를 조회합니다.")
+    @Operation(summary = "내가 쓴 스토리 조회", description = "본인이 작성한 스토리를 조회합니다.")
     @GetMapping("/mystories") // 특정 분기 조회
     public ResponseEntity<ResultResponse> getStoriesByNickname(HttpServletRequest request) {
-        Long userId = tokenService.getUserIdFromToken(request);
-        String nickname = userRepository.findNicknameById(userId)
-                .orElseThrow(UserNotFoundException::new);
-        List<StoryListResponseDTO> storiesByNickname = mypageService.getStoriesByNickname(nickname);
+        List<StoryListResponseDTO> storiesByNickname = mypageService.getStoriesByNickname(request);
         return ResponseEntity.ok(ResultResponse.of(MYPAGE_MYSTORY_LIST_SUCCESS, storiesByNickname));
     }
 }

--- a/src/main/java/com/nextpage/backend/service/MypageService.java
+++ b/src/main/java/com/nextpage/backend/service/MypageService.java
@@ -1,11 +1,13 @@
 package com.nextpage.backend.service;
 
+import com.nextpage.backend.config.jwt.TokenService;
 import com.nextpage.backend.dto.response.StoryListResponseDTO;
 import com.nextpage.backend.entity.Story;
 import com.nextpage.backend.error.exception.story.StoryNotFoundException;
 import com.nextpage.backend.error.exception.user.UserNotFoundException;
 import com.nextpage.backend.repository.StoryRepository;
 import com.nextpage.backend.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -16,13 +18,18 @@ import java.util.List;
 public class MypageService {
     private final StoryRepository storyRepository;
     private final UserRepository userRepository;
+    private final TokenService tokenService;
 
-    public MypageService(StoryRepository storyRepository, UserRepository userRepository) {
+    public MypageService(StoryRepository storyRepository, UserRepository userRepository, TokenService tokenService) {
         this.storyRepository = storyRepository;
         this.userRepository = userRepository;
+        this.tokenService = tokenService;
     }
 
-    public List<StoryListResponseDTO> getStoriesByNickname(String nickname) { //내가 작성한 스토리 조회
+    public List<StoryListResponseDTO> getStoriesByNickname(HttpServletRequest request) { //내가 작성한 스토리 조회
+        Long userId = tokenService.getUserIdFromToken(request);
+        String nickname = userRepository.findNicknameById(userId)
+                .orElseThrow(UserNotFoundException::new);
         List<Story> result= storyRepository.findStoriesByNickname(nickname);
         if(!userRepository.existsByNickname(nickname)) {
             throw new UserNotFoundException();


### PR DESCRIPTION
## Summary
*한 줄 설명*
mypageService 수정하여 헤더에서 토큰 받고 토큰에서 ID받고 ID를 통해 닉네임을 가져오도록 수정

## Description
- *어떤 코드가 추가/변경 됐는지*
- mypageService 수정하여 헤더에서 토큰 받고 토큰에서 ID받고 ID를 통해 닉네임을 가져오도록 수정
- 이제 더이상 내가 작성한 스토리 조회하기 api에서는 nickname parameter가 필요하지 않음

## Screenshots
*실행 결과 스크린샷*
![image](https://github.com/Project-NextPage/nextpage_backend/assets/85006156/f302d546-072f-4e69-ae1a-6ebf7ce1c8a6)


## Test Checklist
- [ ] *테스트할 사람이 어떤 것을 확인하면 좋을지*
- [ ] 
