### PR TITLE
feat: K6, InfluxDB, Grafana를 이용한 부하테스트 시각화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-monitoring
+monitoring/grafana/
 ### STS ###
 .apt_generated
 .classpath

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,40 @@ services:
     volumes:
       - './monitoring/grafana:/var/lib/grafana'
     restart: always
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    networks:
+      - npage
+
+  k6:
+    image: grafana/k6:latest
+    container_name: k6
+    networks:
+      - npage
+    ports:
+      - "6565:6565"
+    environment:
+      - K6_OUT=influxdb=http://influxdb:8086/k6
+    volumes:
+      - ./monitoring/k6:/scripts
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # 호스트와 연결(로컬테스트를 위함)
+    command: ["run", "/scripts/test_script.js"]
+
+  influxdb:
+    image: influxdb:1.8
+    ports:
+      - "8086:8086"
+    environment:
+      - INFLUXDB_DB=k6
+    restart: on-failure # 실패 시 재시작
+    networks:
+      - npage
 
 networks:
   npage:
     driver: bridge
+
+

--- a/monitoring/k6/test_script.js
+++ b/monitoring/k6/test_script.js
@@ -1,0 +1,50 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+    stages: [
+        { duration: '30s', target: 20 }, // 첫번째 스테이지 : 30초동안 사용자 수를 0 -> 20으로 증가
+        { duration: '1m', target: 20 },  // 두번째 스테이지 : 1분간 사용자 수를 20으로 유지
+        { duration: '10s', target: 0 },  // 세번째 스테이지 : 10초간 사용자 수를 20 -> 0으로 감소
+    ],
+};
+
+// Base URL
+const BASE_URL = 'http://springboot:8080/api/v2';
+
+// Headers
+const headers = {
+    'Content-Type': 'application/json',
+};
+
+export default function () {
+    // 루트 스토리 조회
+    let rootStoriesRes = http.get(`${BASE_URL}/stories`, { headers });
+    check(rootStoriesRes, {
+        'getRootStories is status 200': (r) => r.status === 200,
+        'getRootStories response time is less than 200ms': (r) => r.timings.duration < 200,
+    });
+
+    // 스토리 상세 조회 (storyId = 1 예시)
+    let storyDetailsRes = http.get(`${BASE_URL}/stories/details/1`, { headers });
+    check(storyDetailsRes, {
+        'getStoryDetails is status 200': (r) => r.status === 200,
+        'getStoryDetails response time is less than 200ms': (r) => r.timings.duration < 200,
+    });
+
+    // 시나리오 조회 (rootId = 1 예시)
+    let scenarioRes = http.get(`${BASE_URL}/stories/1`, { headers });
+    check(scenarioRes, {
+        'getStoriesByRootId is status 200': (r) => r.status === 200,
+        'getStoriesByRootId response time is less than 200ms': (r) => r.timings.duration < 200,
+    });
+
+    // 특정 분기 조회 (storyId = 1 예시)
+    let branchStoriesRes = http.get(`${BASE_URL}/stories/branch/1`, { headers });
+    check(branchStoriesRes, {
+        'getStoriesByleafId is status 200': (r) => r.status === 200,
+        'getStoriesByleafId response time is less than 200ms': (r) => r.timings.duration < 200,
+    });
+
+    sleep(1);
+}


### PR DESCRIPTION
## Summary
도커를 빌드하면, 아래 사진과 같은 결과가 로그에 나옵니다.
![image](https://github.com/Project-NextPage/nextpage_backend/assets/113340283/af9a9863-4cc4-4750-be76-488e7a338d2c)

이를 그라파나에 확인하기 위해서는 대시보드 설정을 해야합니다. 자세한 과정은 링크를 참고해주세요. 
(https://legend-quiver-68a.notion.site/3ef226872c2941a6b458944d805f2773?pvs=4)

그라파나 도커 설정에서, 초기 로그인을 하지 않아도 되는 environmnet 설정도 추가했습니다. 
    environment:
      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
      - GF_AUTH_ANONYMOUS_ENABLED=true
      - GF_AUTH_BASIC_ENABLED=false
      
최종적으로 API별 처리 속도를 구현한 대시보드는 아래 사진과 같습니다. 
![image](https://github.com/Project-NextPage/nextpage_backend/assets/113340283/ccc17419-ce34-4177-906e-950822339113)

한번씩 대시보드 만들어보시면 좋을 것같아요. 임포트한 대시보드에 API별 처리속도를 커스텀해서 추가했습니다. 
대시보드 아이디는 2587입니다.

현재 진행하고 있는 API들은 토큰을 사용하지 않는 API들이고, 토큰을 필요한 것들은 실제로 로그인 후 토큰을 반환하는 과정이 필요해서 일단 제외했습니다. 현재 테스트하는 것들이 이미지 리사이징과 가장 큰 관련이 있는 API들이고, 추후에 버킷을 비우고 전후를 비교해볼 예정입니다. 

그리고 .gitignore를 수정했습니다. 모니터링 폴더 전체가 아닌, 모니터링 - 그라파나 폴더만 추가되어 있으니, 모니터링을 하고 계시는 분들은 볼륨을 올리지 않게 주의해주세요! 

K6는 원래 한번 실행되고 끝나요! exit 떠도 괜찮습니다 ^____^ (K6는 명령어와 스크립트 기반으로 실행되고, 더이상 실행할 내용이 없으면 자동으로 종료됨)